### PR TITLE
chore: mark polygon as core deployment

### DIFF
--- a/apps/lite/src/lib/constants.tsx
+++ b/apps/lite/src/lib/constants.tsx
@@ -1,6 +1,6 @@
 import { type Deployments } from "@morpho-org/uikit/lib/deployments";
 import { ReactNode } from "react";
-import { optimism, polygon, worldchain } from "wagmi/chains";
+import { optimism, plumeMainnet, polygon, worldchain } from "wagmi/chains";
 
 export const APP_DETAILS = {
   // NOTE: Should always match the title in `index.html` (won't break anything, but should be correct)
@@ -14,7 +14,7 @@ export const WORDMARK = ""; // Replace with "/your-wordmark.svg" to customize in
 
 export const MIN_TIMELOCK = 3 * 24 * 60 * 60; // For filtering vaults
 
-export const DEFAULT_CHAIN = polygon;
+export const DEFAULT_CHAIN = plumeMainnet;
 
 export const TERMS_OF_USE = "https://cdn.morpho.org/documents/Morpho_Terms_of_Use.pdf";
 export const RISKS_DOCUMENTATION = "https://docs.morpho.org/overview/resources/risks/";

--- a/packages/uikit/src/lib/deployments.ts
+++ b/packages/uikit/src/lib/deployments.ts
@@ -120,7 +120,7 @@ export const DEPLOYMENTS: Deployments = {
   },
 };
 
-export const CORE_DEPLOYMENTS = new Set<keyof Deployments>([mainnet.id, base.id]);
+export const CORE_DEPLOYMENTS = new Set<keyof Deployments>([mainnet.id, base.id, polygon.id]);
 
 export function getContractDeploymentInfo(chainId: number, name: OptionalContracts): DeploymentDetails | undefined;
 export function getContractDeploymentInfo(chainId: number, name: RequiredContracts): DeploymentDetails;


### PR DESCRIPTION
Hides polygon in the chain dropdown unless user holds "shift", and sets Plume as the default chain (suggested by Kirk).