### PR TITLE
chore(lite): hide all roles except owner in vault table

### DIFF
--- a/apps/lite/src/app/dashboard/borrow-subpage.tsx
+++ b/apps/lite/src/app/dashboard/borrow-subpage.tsx
@@ -117,7 +117,7 @@ export function BorrowSubPage() {
           name: vaultData.vault.name,
           address: vaultData.vault.vault,
           totalAssets: vaultData.vault.totalAssets,
-          curators: getDisplayableCurators(vaultData.vault, topCurators),
+          curators: getDisplayableCurators({ ...vaultData.vault, address: vaultData.vault.vault }, topCurators),
         });
       });
     });

--- a/apps/lite/src/components/borrow-table.tsx
+++ b/apps/lite/src/components/borrow-table.tsx
@@ -156,22 +156,24 @@ function VaultsTableCell({
               <div className="flex items-center justify-between font-light">
                 <span>Curators</span>
                 <div className="flex items-end gap-1">
-                  {Object.values(vault.curators).map((curator) => (
-                    <a
-                      key={curator.name}
-                      className="hover:bg-secondary flex gap-1 rounded-sm p-1"
-                      href={curator.url ?? ""}
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      {curator.imageSrc && (
-                        <Avatar className="size-4 rounded-full">
-                          <AvatarImage src={curator.imageSrc} alt="Loan Token" />
-                        </Avatar>
-                      )}
-                      {curator.name}
-                    </a>
-                  ))}
+                  {Object.values(vault.curators)
+                    .filter((curator) => curator.shouldAlwaysShow)
+                    .map((curator) => (
+                      <a
+                        key={curator.name}
+                        className="hover:bg-secondary flex gap-1 rounded-sm p-1"
+                        href={curator.url ?? ""}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        {curator.imageSrc && (
+                          <Avatar className="size-4 rounded-full">
+                            <AvatarImage src={curator.imageSrc} alt="Loan Token" />
+                          </Avatar>
+                        )}
+                        {curator.name}
+                      </a>
+                    ))}
                 </div>
               </div>
               {token.decimals !== undefined && (

--- a/apps/lite/src/components/earn-table.tsx
+++ b/apps/lite/src/components/earn-table.tsx
@@ -115,24 +115,29 @@ function CuratorTableCell({
           className="text-primary-foreground rounded-3xl p-4 shadow-2xl"
           onClick={(e) => e.stopPropagation()}
         >
-          <p className="underline">Roles</p>
-          {roles.map((role) => (
-            <div className="flex items-center gap-1" key={role.name}>
-              <p>
-                {role.name}: <code>{abbreviateAddress(role.address)}</code>
-              </p>
-              {chain?.blockExplorers?.default.url && (
-                <a
-                  href={`${chain.blockExplorers.default.url}/address/${role.address}`}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                </a>
-              )}
-            </div>
-          ))}
-          <br />
+          {/* It's possible for a curator to have no onchain roles. In that case, just show their URL. */}
+          {roles.length > 0 && (
+            <>
+              <p className="underline">Roles</p>
+              {roles.map((role) => (
+                <div className="flex items-center gap-1" key={role.name}>
+                  <p>
+                    {role.name}: <code>{abbreviateAddress(role.address)}</code>
+                  </p>
+                  {chain?.blockExplorers?.default.url && (
+                    <a
+                      href={`${chain.blockExplorers.default.url}/address/${role.address}`}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  )}
+                </div>
+              ))}
+              <br />
+            </>
+          )}
           {url != null && (
             <a className="text-blue-200 underline" href={url} rel="noopener noreferrer" target="_blank">
               {url}
@@ -282,7 +287,9 @@ export function EarnTable({
                       <div className="flex w-min gap-2">
                         {Object.keys(row.curators).length > 0
                           ? Object.values(row.curators)
-                              .slice(0, isShiftHeld ? undefined : 1)
+                              // By default, only show roles with `shouldAlwaysShow == true`.
+                              // When shift key is held, remove filter and show all roles.
+                              .filter((curator) => (isShiftHeld ? true : curator.shouldAlwaysShow))
                               .map((curator) => <CuratorTableCell key={curator.name} {...curator} chain={chain} />)
                           : ownerText}
                       </div>

--- a/apps/lite/src/components/earn-table.tsx
+++ b/apps/lite/src/components/earn-table.tsx
@@ -11,6 +11,7 @@ import {
   Table,
 } from "@morpho-org/uikit/components/shadcn/table";
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@morpho-org/uikit/components/shadcn/tooltip";
+import { useModifierKey } from "@morpho-org/uikit/hooks/use-modifier-key";
 import { formatBalanceWithSymbol, Token, formatLtv, abbreviateAddress } from "@morpho-org/uikit/lib/utils";
 import { blo } from "blo";
 // @ts-expect-error: this package lacks types
@@ -235,6 +236,8 @@ export function EarnTable({
   lendingRewards: ReturnType<typeof useMerklOpportunities>;
   refetchPositions: () => void;
 }) {
+  const isShiftHeld = useModifierKey("Shift");
+
   return (
     <div className="text-primary-foreground w-full max-w-7xl px-2 lg:px-8">
       <Table className="border-separate border-spacing-y-3">
@@ -278,9 +281,9 @@ export function EarnTable({
                     <TableCell>
                       <div className="flex w-min gap-2">
                         {Object.keys(row.curators).length > 0
-                          ? Object.values(row.curators).map((curator) => (
-                              <CuratorTableCell key={curator.name} {...curator} chain={chain} />
-                            ))
+                          ? Object.values(row.curators)
+                              .slice(0, isShiftHeld ? undefined : 1)
+                              .map((curator) => <CuratorTableCell key={curator.name} {...curator} chain={chain} />)
                           : ownerText}
                       </div>
                     </TableCell>


### PR DESCRIPTION
Requested by MEV. For power users, other roles are still visible if you hold the Shift key (similar to how extra chains can be revealed).

Closes INTEG-2654
Closes INTEG-2694