### PR TITLE
fix(lite): refactor merkl api usage and fix MORPHOSUPPLY campaign type

### DIFF
--- a/apps/lite/src/app/dashboard/borrow-subpage.tsx
+++ b/apps/lite/src/app/dashboard/borrow-subpage.tsx
@@ -42,7 +42,7 @@ export function BorrowSubPage() {
     [chainId],
   );
 
-  const borrowingRewards = useMerklOpportunities({ chainId, subType: Merkl.SubType.BORROW, userAddress });
+  const borrowingRewards = useMerklOpportunities({ chainId, side: Merkl.CampaignSide.BORROW, userAddress });
 
   // MARK: Index `MetaMorphoFactory.CreateMetaMorpho` on all factory versions to get a list of all vault addresses
   const {

--- a/apps/lite/src/app/dashboard/earn-subpage.tsx
+++ b/apps/lite/src/app/dashboard/earn-subpage.tsx
@@ -44,7 +44,7 @@ export function EarnSubPage() {
     [chainId],
   );
 
-  const lendingRewards = useMerklOpportunities({ chainId, subType: Merkl.SubType.LEND, userAddress });
+  const lendingRewards = useMerklOpportunities({ chainId, side: Merkl.CampaignSide.EARN, userAddress });
 
   // MARK: Index `MetaMorphoFactory.CreateMetaMorpho` on all factory versions to get a list of all vault addresses
   const {

--- a/apps/lite/src/components/rewards-button.tsx
+++ b/apps/lite/src/components/rewards-button.tsx
@@ -24,7 +24,7 @@ export function RewardsButton({ chainId }: { chainId: number | undefined }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { address: userAddress } = useAccount();
-  const { data: morphoCampaigns } = useMerklCampaigns({ chainId, subType: undefined, withOpportunity: false });
+  const { data: morphoCampaigns } = useMerklCampaigns({ chainId, side: undefined, withOpportunity: false });
   const rewards = useMerklRewards({
     chainId,
     address: userAddress,

--- a/apps/lite/src/hooks/use-merkl-campaigns.ts
+++ b/apps/lite/src/hooks/use-merkl-campaigns.ts
@@ -68,8 +68,6 @@ async function queryFn({ queryKey }: { queryKey: QueryKey }) {
       linearized.get(fields.subType)?.push(fields.type);
     }
 
-    console.log("linearized", linearized);
-
     linearized.forEach((types, subType) =>
       promises.push(
         merkl.campaigns.index.get({

--- a/apps/lite/src/hooks/use-merkl-campaigns.ts
+++ b/apps/lite/src/hooks/use-merkl-campaigns.ts
@@ -3,58 +3,96 @@ import { type QueryKey, useQuery } from "@tanstack/react-query";
 
 const merkl = MerklApi("https://api.merkl.xyz").v4;
 
-export enum SubType {
-  LEND,
-  UNUSED,
+export enum CampaignSide {
+  EARN,
   BORROW,
+  COLLATERALIZE,
 }
 
-// Updated 06/06/2025, subject to change by Merkl
-const MERKL_LISTING_TYPES: Record<SubType, string[]> = {
-  [SubType.LEND]: ["MORPHOVAULT", "MORPHOSUPPLY", "ERC20LOGPROCESSOR"], // market and vault-based lending, respectively
-  [SubType.UNUSED]: [],
-  [SubType.BORROW]: ["MORPHOBORROW"],
-  // TODO: MORPHOCOLLATERAL (no campaigns with this for now, and UI doesn't support it)
+export enum CampaignType {
+  Old = "MORPHO",
+  DepositToErc4626 = "ERC20LOGPROCESSOR",
+  DepositToVaultV1 = "MORPHOVAULT",
+  SupplyToMarketV1 = "MORPHOSUPPLY",
+  SupplyCollateralToMarketV1 = "MORPHOCOLLATERAL",
+  BorrowFromMarketV1 = "MORPHOBORROW",
+}
+
+export type CampaignSubType = 0 | 1 | 2;
+
+export const CAMPAIGN_PARAM_KEYS: Record<CampaignType, Partial<Record<CampaignSubType, string>>> = {
+  [CampaignType.Old]: { 0: "targetToken", 2: "marketId" },
+  [CampaignType.DepositToErc4626]: { 0: "targetToken" },
+  [CampaignType.DepositToVaultV1]: { 0: "targetToken" },
+  [CampaignType.SupplyToMarketV1]: { 0: "market" },
+  [CampaignType.BorrowFromMarketV1]: { 0: "market" },
+  [CampaignType.SupplyCollateralToMarketV1]: { 0: "market" },
+};
+
+const SIDE_CAMPAIGN_TYPES: Record<CampaignSide, { type: CampaignType; subType?: CampaignSubType }[]> = {
+  [CampaignSide.EARN]: [
+    { type: CampaignType.Old, subType: 0 },
+    { type: CampaignType.DepositToErc4626 },
+    { type: CampaignType.DepositToVaultV1 },
+    { type: CampaignType.SupplyToMarketV1 },
+  ],
+  [CampaignSide.BORROW]: [{ type: CampaignType.Old, subType: 2 }, { type: CampaignType.BorrowFromMarketV1 }],
+  [CampaignSide.COLLATERALIZE]: [{ type: CampaignType.SupplyCollateralToMarketV1 }],
 };
 
 async function queryFn({ queryKey }: { queryKey: QueryKey }) {
-  const [subType, chainId, withOpportunity] = queryKey.slice(4) as [SubType | undefined, number, boolean];
+  const [side, chainId, withOpportunity] = queryKey.slice(4) as [CampaignSide | undefined, number, boolean];
 
-  const [campaignsOld, campaignsNew] = await Promise.all([
-    merkl.campaigns.index.get({
-      query: {
-        chainId,
-        status: "LIVE",
-        type: "MORPHO",
-        withOpportunity,
-        items: 100,
-        ...(subType !== undefined ? { subType } : {}),
-      },
-    }),
-    merkl.campaigns.index.get({
-      query: {
-        chainId,
-        status: "LIVE",
-        // @ts-expect-error: This version of the Merkl API package lacks this field, even though it's supported.
-        // The next major version includes it, but breaks typing on the `Opportunity` return field
-        mainProtocolId: "morpho",
-        withOpportunity,
-        items: 100,
-        ...(subType !== undefined ? { types: MERKL_LISTING_TYPES[subType] } : {}),
-      },
-    }),
-  ]);
+  // The basic query, specifying everything except `type` and `subType`
+  const query = {
+    chainId,
+    withOpportunity,
+    mainProtocolId: "morpho",
+    status: "LIVE",
+    items: 100,
+  } as const;
 
-  if (campaignsOld.error) {
-    console.error("Error fetching campaigns from Merkl API");
-    throw new Error(JSON.stringify(campaignsOld.error));
+  const promises: ReturnType<typeof merkl.campaigns.index.get>[] = [];
+
+  if (side === undefined) {
+    // Fetch with no type/subType filtering
+    promises.push(merkl.campaigns.index.get({ query }));
+  } else {
+    // Fetch with type/subType filtering. `type`s that share a specific `subType`
+    // can be combined for querying the Merkl API.
+    const linearized = new Map<CampaignSubType | undefined, CampaignType[]>();
+    for (const fields of SIDE_CAMPAIGN_TYPES[side]) {
+      if (!linearized.has(fields.subType)) {
+        linearized.set(fields.subType, []);
+      }
+      linearized.get(fields.subType)?.push(fields.type);
+    }
+
+    console.log("linearized", linearized);
+
+    linearized.forEach((types, subType) =>
+      promises.push(
+        merkl.campaigns.index.get({
+          query: {
+            ...query,
+            types,
+            ...(subType !== undefined ? { subType } : {}),
+          },
+        }),
+      ),
+    );
   }
-  if (campaignsNew.error) {
-    console.error("Error fetching campaigns from Merkl API");
-    throw new Error(JSON.stringify(campaignsNew.error));
+
+  const results = await Promise.all(promises);
+  for (const result of results) {
+    if (result.error) {
+      console.error("Error fetching campaigns from Merkl API");
+      throw new Error(JSON.stringify(result.error));
+    }
   }
 
-  const campaigns = campaignsOld.data.concat(campaignsNew.data);
+  const campaigns = results.map((result) => result.data!).flat(1);
+
   return withOpportunity
     ? campaigns.filter((campaign) => campaign.Opportunity?.status === "LIVE" && campaign.parentCampaignId === undefined)
     : campaigns;
@@ -62,15 +100,15 @@ async function queryFn({ queryKey }: { queryKey: QueryKey }) {
 
 export function useMerklCampaigns({
   chainId,
-  subType,
+  side,
   withOpportunity = true,
 }: {
   chainId: number | undefined;
-  subType?: SubType;
+  side?: CampaignSide;
   withOpportunity?: boolean;
 }) {
   return useQuery({
-    queryKey: ["merkl", "campaigns", "LIVE", "MORPHO", subType, chainId, withOpportunity],
+    queryKey: ["merkl", "campaigns", "LIVE", "MORPHO", side, chainId, withOpportunity],
     queryFn,
     staleTime: 5 * 60 * 1_000,
     enabled: chainId !== undefined,

--- a/apps/lite/src/hooks/use-merkl-campaigns.ts
+++ b/apps/lite/src/hooks/use-merkl-campaigns.ts
@@ -73,7 +73,7 @@ async function queryFn({ queryKey }: { queryKey: QueryKey }) {
         merkl.campaigns.index.get({
           query: {
             ...query,
-            types,
+            ...(types.length > 1 ? { types } : { type: types[0] }),
             ...(subType !== undefined ? { subType } : {}),
           },
         }),

--- a/apps/lite/src/lib/wagmi-config.ts
+++ b/apps/lite/src/lib/wagmi-config.ts
@@ -144,7 +144,10 @@ const transports: { [K in (typeof chains)[number]["id"]]: Transport } & { [k: nu
     { url: `https://rpc-katana.t.conduit.xyz/${import.meta.env.VITE_KATANA_KEY}`, batch: false },
     ...customChains.katana.rpcUrls.default.http.map((url) => ({ url, batch: false })),
   ]),
-  [customChains.tac.id]: createFallbackTransport([{ url: "https://rpc.tac.build/", batch: { batchSize: 10 } }]),
+  [customChains.tac.id]: createFallbackTransport([
+    { url: `https://rpc.ankr.com/tac/${import.meta.env.VITE_ANKR_API_KEY}`, batch: { batchSize: 10 } },
+    { url: "https://rpc.tac.build/", batch: { batchSize: 10 } },
+  ]),
 };
 
 export function createConfig(args: {

--- a/apps/lite/src/vite-env.d.ts
+++ b/apps/lite/src/vite-env.d.ts
@@ -4,6 +4,7 @@
 interface ImportMetaEnv {
   readonly VITE_WALLET_KIT_PROJECT_ID: string;
   readonly VITE_ALCHEMY_API_KEY: string;
+  readonly VITE_ANKR_API_KEY: string;
   readonly VITE_APP_TITLE: string;
   readonly VITE_KATANA_KEY: string;
 }

--- a/packages/uikit/src/lib/utils.ts
+++ b/packages/uikit/src/lib/utils.ts
@@ -91,9 +91,13 @@ export function getTokenSymbolURI(symbol: string | undefined): Token["imageSrc"]
   } else if (symbol === "M-BTC") {
     // TODO: remove once it's included on Morpho CDN
     return "https://s2.coinmarketcap.com/static/img/coins/64x64/34686.png";
+  } else if (symbol === "USD₮") {
+    return "https://cdn.morpho.org/assets/logos/usdt.svg";
   } else if (symbol === "USD₮0") {
     // TODO: remove once it's included on Morpho CDN
     return "https://assets.coingecko.com/coins/images/53705/standard/usdt0.jpg";
+  } else if (symbol === "TON") {
+    return "https://s2.coinmarketcap.com/static/img/coins/64x64/11419.png";
   }
   return `https://cdn.morpho.org/assets/logos/${encodeURIComponent((symbol ?? "").toLowerCase())}.svg`;
 }


### PR DESCRIPTION
Closes PRIME-586

Unrelated: adds token logos for TAC, add Ankr API key